### PR TITLE
Fix KeyError for opencv_enabled in camera config

### DIFF
--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -1278,7 +1278,7 @@ def motion_camera_ui_to_dict(ui, prev_config=None):
 
     data['on_movie_end'] = '; '.join(on_movie_end)
 
-    data['@opencv_enabled'] = ui['opencv_enabled']
+    data['@opencv_enabled'] = ui.get('opencv_enabled', False)
 
     # picture save
     on_picture_save = [f"{meyectl.find_command('relayevent')} picture_save %t %f"]


### PR DESCRIPTION
When updating camera settings from the web UI, a `KeyError: 'opencv_enabled'` could occur. This happened because the backend code was directly accessing the `opencv_enabled` key from the UI data.

If the "Enable OpenCV" checkbox was unchecked, the key would not be sent in the form data, leading to the error.

This commit fixes the issue by using the `.get()` dictionary method with a default value of `False`. This ensures that the application handles the absence of the key gracefully.