### PR TITLE
docs: Add server shutdown instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ If you are a developer and you want to run motionEye without installing it as a 
     ```
     The server will be running in the foreground and will be accessible at `http://localhost:8765`.
 
+# Starting and Stopping the Server
+
+For detailed instructions on how to start and stop the motionEye server, for both development and production environments, please see [`LAUNCH.md`](./LAUNCH.md).
+
 # Upgrade
 
 ### For Users (from PyPI)


### PR DESCRIPTION
This commit adds a new "Starting and Stopping the Server" section to README.md. This section provides a brief overview of how to run the server and links to the LAUNCH.md file for more detailed instructions on starting and stopping the server in both development and production environments.

This makes the shutdown instructions more discoverable for users.