### PR TITLE
Fix(ui): Correctly handle authentication for the 'Manage Faces' page

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -978,6 +978,13 @@ function initUI() {
     $('div#backupButton').on('click', doBackup);
     $('div#restoreButton').on('click', doRestore);
 
+    /* manage faces button */
+    $('div#manageFacesButton').on('click', function () {
+        var url = basePath + 'faces.html';
+        url = addAuthParams('GET', url);
+        window.open(url, '_blank');
+    });
+
     /* test buttons */
     $('div#uploadTestButton').on('click', doTestUpload);
     $('div#emailTestButton').on('click', doTestEmail);

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -245,7 +245,7 @@
                         </tr>
                         <tr class="settings-item">
                             <td class="settings-item-label"><span class="settings-item-label">Familiar Faces</span></td>
-                            <td class="settings-item-value"><a href="/faces.html" target="_blank" class="button normal-button">Manage Faces</a></td>
+                            <td class="settings-item-value"><div id="manageFacesButton" class="button normal-button">Manage Faces</div></td>
                             <td><span class="help-mark" title="Manage the list of known faces for recognition.">?</span></td>
                         </tr>
                     </table>


### PR DESCRIPTION
The 'Manage Faces' button was previously a simple hyperlink, which caused an authorization error because it did not include the necessary authentication parameters in the request.

This commit fixes the issue by:
1.  Changing the hyperlink to a `div` element in `main.html`.
2.  Adding a JavaScript click handler in `main.js` that:
    - Constructs the URL for the 'Manage Faces' page.
    - Uses the existing `addAuthParams` function to add the required authentication parameters.
    - Opens the authenticated URL in a new tab.

This ensures that the request to the 'Manage Faces' page is properly authenticated, resolving the 'unauthorized' error.