### PR TITLE
feat: Add theme switcher with dark and glass modes

### DIFF
--- a/conf/prefs.json
+++ b/conf/prefs.json
@@ -1,0 +1,10 @@
+{
+    "admin": {
+        "fit_frames_vertically": true,
+        "framerate_factor": 1,
+        "layout_columns": 3,
+        "layout_rows": 1,
+        "resolution_factor": 1,
+        "theme": "glass"
+    }
+}

--- a/motioneye/.gitignore
+++ b/motioneye/.gitignore
@@ -1,1 +1,5 @@
 traduko.jar
+*.pyc
+__pycache__/
+/conf/prefs.json
+/meyectl.log

--- a/motioneye/prefs.py
+++ b/motioneye/prefs.py
@@ -27,6 +27,7 @@ _DEFAULT_PREFS = {
     'layout_rows': 1,
     'framerate_factor': 1,
     'resolution_factor': 1,
+    'theme': 'dark',
 }
 
 _prefs = None

--- a/motioneye/static/css/main.css
+++ b/motioneye/static/css/main.css
@@ -1,6 +1,4 @@
-
-
-    /* basic */
+/* basic */
 
 * {
     padding: 0;
@@ -18,9 +16,7 @@ html {
 
 body {
     height: 100%;
-    color: #dddddd;
     font-size: 22px;
-    background-color: #212121;
 }
 
 select,
@@ -68,7 +64,6 @@ div.page {
 }
 
 div.header {
-    background-color: rgba(64, 64, 64, 0.5);
     box-shadow: 0 0 5px rgba(0,0,0,0.3);
     top: 0;
     width: 100%;
@@ -96,14 +91,12 @@ div.footer {
     width: 100%;
     height: 3em;
     font-size: 0.7em;
-    color: #aaa;
     text-align: center;
     transition: all 0.2s ease;
     overflow: hidden;
 }
 
 div.copyright-note {
-    border-top: 1px solid #333;
     padding-top: 0.2em;
     margin: 0 15%;
 }
@@ -187,7 +180,6 @@ div.logo {
 }
 
 span.logo {
-    color: white;
     vertical-align: middle;
     font-size: 27px;
     font-weight: bold;
@@ -235,7 +227,6 @@ div.hostname {
     /* settings */
 
 div.settings {
-    background-color: #313131;
     position: fixed;
     z-index: 2;
     top: 50px;
@@ -268,7 +259,6 @@ div.settings-progress {
     width: 0;
     bottom: 0;
     left: 0;
-    background-color: #313131;
     opacity: 0;
     transition: opacity 0.1s linear;
 }
@@ -281,7 +271,6 @@ div.settings-top-bar {
 }
 
 div.settings-top-bar.open {
-    background-color: #414141;
     min-width: 360px;
 }
 
@@ -292,7 +281,6 @@ div.settings-top-bar.closed div.apply-button {
 div.settings-section-title {
     position: relative;
     text-align: right;
-    background-color: rgba(100, 100, 100, 0.3);
     padding: 5px 0.5em 5px 5px;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -327,7 +315,6 @@ span.settings-item-unit {
 
 div.settings-item-separator {
     height: 1px;
-    border-top: 1px solid #414141;
     margin: 0.5em 1em;
 }
 
@@ -350,22 +337,8 @@ div.apply-button {
     line-height: 30px;
     text-align: center;
     margin: 10px;
-    color: white;
-    background-color: #FF6F00;
     border-radius: 3px;
     transition: all 0.1s linear;
-}
-
-div.apply-button:HOVER {
-    background-color: #FF7D19;
-}
-
-div.apply-button:ACTIVE {
-    background-color: #F06800;
-}
-
-div.apply-button.progress {
-    background-color: #FF6F00;
 }
 
 img.apply-progress {
@@ -378,61 +351,15 @@ div.normal-button {
     line-height: 1.5em;
     text-align: center;
     margin: 2px 0;
-    color: white;
     font-size: 0.9em;
     border-radius: 3px;
     transition: all 0.1s linear;
     width: 8em;
 }
 
-div.update-button,
-div.backup-button,
-div.restore-button,
-div.edit-mask-button,
-div.save-mask-button,
-div.clear-mask-button,
-div.test-button {
-    background: #317CAD;
-}
-
 div.save-mask-button,
 div.clear-mask-button {
     display: none;
-}
-
-div.shut-down-button,
-div.reboot-button {
-    background: #c0392b;
-}
-
-div.update-button:HOVER,
-div.backup-button:HOVER,
-div.restore-button:HOVER,
-div.edit-mask-button:HOVER,
-div.save-mask-button:HOVER,
-div.clear-mask-button:HOVER,
-div.test-button:HOVER {
-    background: #3498db;
-}
-
-div.shut-down-button:HOVER,
-div.reboot-button:HOVER {
-    background: #D43F2F;
-}
-
-div.update-button:ACTIVE,
-div.backup-button:ACTIVE,
-div.restore-button:ACTIVE,
-div.edit-mask-button:ACTIVE,
-div.save-mask-button:ACTIVE,
-div.clear-mask-button:ACTIVE,
-div.test-button:ACTIVE {
-    background: #317CAD;
-}
-
-div.shut-down-button:ACTIVE,
-div.reboot-button:ACTIVE {
-    background: #B03427;
 }
 
 div.settings-top-bar.open #cameraSelect {
@@ -446,19 +373,6 @@ div.settings-top-bar.open div.logout-button {
 div.check-box.section {
     margin: 0;
     float: left;
-}
-
-div.check-box.section div.check-box-button {
-    background-color: #515151;
-}
-
-div.check-box.on.section div.check-box-button {
-    background-color: #317CAD;
-}
-
-div.check-box.on.section:FOCUS div.check-box-button,
-div.check-box.on.section:HOVER div.check-box-button {
-    background-color: #3498db;
 }
 
 input[type=text].working-schedule.number {
@@ -482,8 +396,6 @@ span.help-mark {
     display: inline-block;
     visibility: hidden;
     text-align: center;
-    background-color: #414141;
-    color: #3498db;
     font-size: 0.75em;
     font-family: monospace;
     width: 1.2em;
@@ -493,10 +405,6 @@ span.help-mark {
     vertical-align: middle;
     position: relative;
     top: -0.1em;
-}
-
-div.settings-section-title > span.help-mark {
-    background-color: #515151;
 }
 
 div.settings-section-title:HOVER > span.help-mark,
@@ -578,8 +486,6 @@ div.media-dialog-group-button {
     text-align: center;
     margin: 0 0.2em 0.2em;
     padding: 0 0.5em;
-    background-color: #414141;
-    color: #3498db;
     border-radius: 3px;
     transition: all 0.1s linear;
     cursor: pointer;
@@ -591,27 +497,6 @@ div.media-dialog-groups.small-screen div.media-dialog-group-button {
     display: inline-block;
 }
 
-div.media-dialog-group-button:HOVER {
-    background-color: #515151;
-}
-
-div.media-dialog-group-button:ACTIVE {
-    background-color: #414141;
-}
-
-div.media-dialog-group-button.current {
-    background-color: #317CAD;
-    color: white;
-}
-
-div.media-dialog-group-button.current:HOVER {
-    background-color: #3498db;
-}
-
-div.media-dialog-group-button.current:ACTIVE {
-    background-color: #317CAD;
-}
-
 div.media-dialog-list {
     overflow: auto;
     position: relative;
@@ -619,7 +504,6 @@ div.media-dialog-list {
 }
 
 div.media-list-group-title {
-    background-color: #313131;
     font-size: 1.3em;
     font-weight: bold;
     text-align: center;
@@ -635,25 +519,16 @@ img.media-list-progress {
 
 div.media-list-entry {
     height: 4em;
-    background-color: #414141;
-    border-bottom: 1px solid #313131;
+    border-bottom: 1px solid;
     cursor: pointer;
     transition: background-color 0.1s linear;
-}
-
-div.media-list-entry:HOVER {
-    background-color: #494949;
-}
-
-div.media-list-entry:ACTIVE {
-    background-color: #3b3b3b;
 }
 
 img.media-list-preview {
     float: left;
     height: 3em;
     margin: 0.45em;
-    border: 1px solid #212121;
+    border: 1px solid;
     box-shadow: 1px 1px 6px rgba(0,0,0,0.3);
 }
 
@@ -689,7 +564,6 @@ div.media-list-delete-button {
     text-align: center;
     margin: 0 0.5em;
     padding: 0 0.5em;
-    color: white;
     border-radius: 3px;
     transition: all 0.1s linear;
 }
@@ -697,29 +571,11 @@ div.media-list-delete-button {
 div.media-list-download-button {
     margin-top: 0.4em;
     margin-bottom: 0.1em;
-    background: #317CAD;
-}
-
-div.media-list-download-button:HOVER {
-    background-color: #3498db;
-}
-
-div.media-list-download-button:ACTIVE {
-    background-color: #317CAD;
 }
 
 div.media-list-delete-button {
     margin-top: 0.1em;
     margin-bottom: 0.4em;
-    background: #c0392b;
-}
-
-div.media-list-delete-button:HOVER {
-    background-color: #D43F2F;
-}
-
-div.media-list-delete-button:ACTIVE {
-    background-color: #B03427;
 }
 
 div.media-dialog-buttons {
@@ -735,18 +591,8 @@ div.media-dialog-button {
     text-align: center;
     padding: 0 0.5em;
     margin: 0 5px 0 0;
-    color: white;
-    background-color: #317CAD;
     border-radius: 3px;
     transition: all 0.1s linear;
-}
-
-div.media-dialog-button:HOVER {
-    background-color: #3498db;
-}
-
-div.media-dialog-button:ACTIVE {
-    background-color: #317CAD;
 }
 
 div.picture-dialog-content {
@@ -814,7 +660,7 @@ img.picture-dialog-content,
 video.picture-dialog-content {
     display: block;
     margin: 0 auto;
-    border: 1px solid #292929;
+    border: 1px solid;
 }
 
 div.picture-dialog-progress {
@@ -841,24 +687,6 @@ td.timelapse-warning {
     padding-bottom: 1em;
 }
 
-div.media-dialog-delete-all-button {
-    margin-top: 0.1em;
-    margin-bottom: 0.4em;
-    background: #c0392b;
-}
-
-div.media-dialog-delete-all-button:HOVER {
-    background-color: #D43F2F;
-}
-
-div.media-dialog-delete-all-button:ACTIVE {
-    background-color: #B03427;
-}
-
-div.button.dialog.delete {
-    background-color: #c0392b;
-}
-
 td.login-dialog-error {
     color: red;
     display: none;
@@ -876,11 +704,9 @@ div.camera-frame {
     position: relative;
     box-sizing: border-box;
     text-align: left;
-    background-color: #313131;
     display: inline-block;
     padding: 0.2em;
     border-radius: 0.1em;
-    border: 0.2em solid #212121;
     border-right-width: 0;
     border-bottom-width: 0;
     transition: all 0.1s ease, opacity 0s;
@@ -891,14 +717,6 @@ div.camera-frame {
     -moz-user-select: none;
     user-select: none;
     overflow: hidden;
-}
-
-div.camera-frame:HOVER {
-    background-color: #414141;
-}
-
-div.camera-frame.motion-detected {
-    background-color: #712727;
 }
 
 div.page-container.one-column div.camera-frame {
@@ -955,21 +773,10 @@ div.camera-overlay.visible {
 div.camera-overlay-top,
 div.camera-overlay-bottom {
     position: absolute;
-    background-color: rgba(0, 0, 0, 0.7);
     transition: background-color 0.1s ease, height 0.2s ease;
     left: 0;
     width: 100%;
     z-index: 1;
-}
-
-div.camera-frame:HOVER div.camera-overlay-top,
-div.camera-frame:HOVER div.camera-overlay-bottom {
-    background-color: rgba(30, 30, 30, 0.8);
-}
-
-div.camera-frame.motion-detected div.camera-overlay-top,
-div.camera-frame.motion-detected div.camera-overlay-bottom {
-    background-color: rgba(113, 39, 39, 0.8);
 }
 
 div.camera-overlay-top {
@@ -982,7 +789,6 @@ div.camera-overlay-top {
 }
 
 div.camera-overlay-mask {
-    background: rgba(255, 255, 255, 0.2);
     opacity: 0;
     position: absolute;
     top: 0;
@@ -1010,9 +816,8 @@ div.camera-overlay.mask-edit > div.camera-overlay-mask {
 div.mask-element {
     position: absolute;
     box-sizing: border-box;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid;
     border-width: 0 1px 1px 0;
-    background: transparent;
 }
 
 div.mask-element.last-row {
@@ -1021,10 +826,6 @@ div.mask-element.last-row {
 
 div.mask-element.last-line {
     border-bottom-width: 0;
-}
-
-div.mask-element.on {
-    background: rgba(255, 0, 0, 0.5);
 }
 
 div.camera-top-row {
@@ -1221,7 +1022,6 @@ div.camera-action-button.preset {
     background-image: url(../img/camera-action-button-preset.svg);
     text-align: center;
     line-height: 2.5em;
-    color: #3498db;
     font-weight: bold;
 }
 
@@ -1314,7 +1114,6 @@ div.camera-progress.visible {
 }
 
 img.camera-progress {
-    border: 10px solid white;
     border-radius: 10px;
     position: absolute;
     top: 0;

--- a/motioneye/static/css/themes.css
+++ b/motioneye/static/css/themes.css
@@ -1,0 +1,411 @@
+/* Classic Theme (Default) */
+body.theme-classic {
+    --bg-color: #212121;
+    --text-color: #dddddd;
+    --header-bg-color: rgba(64, 64, 64, 0.5);
+    --settings-bg-color: #313131;
+    --button-bg-color: #414141;
+    --button-text-color: #dddddd;
+    --accent-color: #3498db;
+    --selection-bg-color: #3498db;
+    --footer-text-color: #aaa;
+    --copyright-border-color: #333;
+    --settings-progress-bg-color: #313131;
+    --settings-section-title-bg-color: rgba(100, 100, 100, 0.3);
+    --settings-item-separator-border-color: #414141;
+    --apply-button-bg-color: #FF6F00;
+    --apply-button-hover-bg-color: #FF7D19;
+    --apply-button-active-bg-color: #F06800;
+    --normal-button-color: white;
+    --update-button-bg-color: #317CAD;
+    --shutdown-button-bg-color: #c0392b;
+    --update-button-hover-bg-color: #3498db;
+    --shutdown-button-hover-bg-color: #D43F2F;
+    --checkbox-section-button-bg-color: #515151;
+    --checkbox-on-section-button-bg-color: #317CAD;
+    --checkbox-on-section-hover-bg-color: #3498db;
+    --help-mark-bg-color: #414141;
+    --help-mark-color: #3498db;
+    --help-mark-section-bg-color: #515151;
+    --camera-frame-bg-color: #313131;
+    --camera-frame-border-color: #212121;
+    --camera-frame-hover-bg-color: #414141;
+    --camera-frame-motion-bg-color: #712727;
+    --camera-overlay-bg-color: rgba(0, 0, 0, 0.7);
+    --camera-overlay-hover-bg-color: rgba(30, 30, 30, 0.8);
+    --camera-overlay-motion-bg-color: rgba(113, 39, 39, 0.8);
+    --camera-overlay-mask-bg-color: rgba(255, 255, 255, 0.2);
+    --mask-element-on-bg-color: rgba(255, 0, 0, 0.5);
+    --preset-button-color: #3498db;
+    --camera-progress-border-color: white;
+    --dialog-button-bg-color: #414141;
+    --dialog-button-border-color: #317CAD;
+    --dialog-button-color: white;
+    --dialog-default-button-bg-color: #317CAD;
+    --checkbox-border-color: #317CAD;
+    --checkbox-color: #aaaaaa;
+    --checkbox-hover-border-color: #3498db;
+    --checkbox-button-bg-color: #414141;
+    --checkbox-button-color: #aaaaaa;
+    --checkbox-on-button-bg-color: #317CAD;
+    --checkbox-on-button-color: white;
+    --input-border-color: #317CAD;
+    --input-bg-color: transparent;
+    --input-color: #dddddd;
+    --input-focus-bg-color: #414141;
+    --input-hover-border-color: #3498db;
+    --input-hover-color: white;
+    --input-readonly-border-color: #555;
+    --slider-bar-border-color: #317CAD;
+    --slider-hover-bar-border-color: #3498db;
+    --slider-focus-bar-bg-color: #414141;
+    --slider-cursor-label-bg-color: rgba(30, 30, 30, 0.8);
+    --progress-bar-border-color: #555;
+    --progress-bar-fill-bg-color: #555;
+    --modal-glass-bg-color: black;
+    --modal-container-bg-color: #313131;
+    --modal-title-color: white;
+    --dialog-separator-border-color: #414141;
+    --popup-container-bg-color: #313131;
+    --popup-info-color: white;
+    --popup-error-color: #FF6D55;
+}
+
+/* Dark Theme */
+body.theme-dark {
+    --bg-color: #1c1c1e;
+    --text-color: #ffffff;
+    --header-bg-color: #2c2c2e;
+    --settings-bg-color: #2c2c2e;
+    --button-bg-color: #3a3a3c;
+    --button-text-color: #ffffff;
+    --accent-color: #0a84ff;
+}
+
+/* Glass Theme */
+body.theme-glass {
+    --bg-color: #1c1c1e;
+    --text-color: #ffffff;
+    --header-bg-color: rgba(44, 44, 46, 0.8);
+    --settings-bg-color: rgba(44, 44, 46, 0.8);
+    --button-bg-color: #3a3a3c;
+    --button-text-color: #ffffff;
+    --accent-color: #0a84ff;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+.page {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+.header {
+    background-color: var(--header-bg-color);
+}
+
+.settings {
+    background-color: var(--settings-bg-color);
+}
+
+.button {
+    background-color: var(--button-bg-color);
+    color: var(--button-text-color);
+}
+
+a {
+    color: var(--accent-color);
+}
+
+.theme-glass .header,
+.theme-glass .settings,
+.theme-glass .modal-container > div {
+    background-color: var(--header-bg-color);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+}
+
+::selection,
+::-moz-selection,
+::-webkit-selection {
+    background: var(--selection-bg-color);
+}
+
+div.footer {
+    color: var(--footer-text-color);
+}
+
+div.copyright-note {
+    border-top: 1px solid var(--copyright-border-color);
+}
+
+span.logo {
+    color: var(--text-color);
+}
+
+div.settings-progress {
+    background-color: var(--settings-progress-bg-color);
+}
+
+div.settings-top-bar.open {
+    background-color: var(--button-bg-color);
+}
+
+div.settings-section-title {
+    background-color: var(--settings-section-title-bg-color);
+}
+
+div.settings-item-separator {
+    border-top: 1px solid var(--settings-item-separator-border-color);
+}
+
+div.apply-button {
+    color: var(--button-text-color);
+    background-color: var(--apply-button-bg-color);
+}
+
+div.apply-button:HOVER {
+    background-color: var(--apply-button-hover-bg-color);
+}
+
+div.apply-button:ACTIVE {
+    background-color: var(--apply-button-active-bg-color);
+}
+
+div.apply-button.progress {
+    background-color: var(--apply-button-bg-color);
+}
+
+div.normal-button {
+    color: var(--normal-button-color);
+}
+
+div.update-button,
+div.backup-button,
+div.restore-button,
+div.edit-mask-button,
+div.save-mask-button,
+div.clear-mask-button,
+div.test-button {
+    background: var(--update-button-bg-color);
+}
+
+div.shut-down-button,
+div.reboot-button {
+    background: var(--shutdown-button-bg-color);
+}
+
+div.update-button:HOVER,
+div.backup-button:HOVER,
+div.restore-button:HOVER,
+div.edit-mask-button:HOVER,
+div.save-mask-button:HOVER,
+div.clear-mask-button:HOVER,
+div.test-button:HOVER {
+    background: var(--update-button-hover-bg-color);
+}
+
+div.shut-down-button:HOVER,
+div.reboot-button:HOVER {
+    background: var(--shutdown-button-hover-bg-color);
+}
+
+div.check-box.section div.check-box-button {
+    background-color: var(--checkbox-section-button-bg-color);
+}
+
+div.check-box.on.section div.check-box-button {
+    background-color: var(--checkbox-on-section-button-bg-color);
+}
+
+div.check-box.on.section:FOCUS div.check-box-button,
+div.check-box.on.section:HOVER div.check-box-button {
+    background-color: var(--checkbox-on-section-hover-bg-color);
+}
+
+span.help-mark {
+    background-color: var(--help-mark-bg-color);
+    color: var(--help-mark-color);
+}
+
+div.settings-section-title > span.help-mark {
+    background-color: var(--help-mark-section-bg-color);
+}
+
+div.camera-frame {
+    background-color: var(--camera-frame-bg-color);
+    border: 0.2em solid var(--camera-frame-border-color);
+}
+
+div.camera-frame:HOVER {
+    background-color: var(--camera-frame-hover-bg-color);
+}
+
+div.camera-frame.motion-detected {
+    background-color: var(--camera-frame-motion-bg-color);
+}
+
+div.camera-overlay-top,
+div.camera-overlay-bottom {
+    background-color: var(--camera-overlay-bg-color);
+}
+
+div.camera-frame:HOVER div.camera-overlay-top,
+div.camera-frame:HOVER div.camera-overlay-bottom {
+    background-color: var(--camera-overlay-hover-bg-color);
+}
+
+div.camera-frame.motion-detected div.camera-overlay-top,
+div.camera-frame.motion-detected div.camera-overlay-bottom {
+    background-color: var(--camera-overlay-motion-bg-color);
+}
+
+div.camera-overlay-mask {
+    background: var(--camera-overlay-mask-bg-color);
+}
+
+div.mask-element.on {
+    background: var(--mask-element-on-bg-color);
+}
+
+div.camera-action-button.preset {
+    color: var(--preset-button-color);
+}
+
+img.camera-progress {
+    border: 10px solid var(--camera-progress-border-color);
+}
+
+div.button.dialog {
+    background-color: var(--dialog-button-bg-color);
+    border: 1px solid var(--dialog-button-border-color);
+    color: var(--dialog-button-color);
+}
+
+div.button.dialog.default {
+    background-color: var(--dialog-default-button-bg-color);
+}
+
+div.icon.mouse-effect:ACTIVE {
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+div.check-box {
+    border: 1px solid var(--checkbox-border-color);
+    color: var(--checkbox-color);
+}
+
+div.check-box:FOCUS,
+div.check-box:HOVER {
+    border-color: var(--checkbox-hover-border-color);
+}
+
+div.check-box-button {
+    background-color: var(--checkbox-button-bg-color);
+    color: var(--checkbox-button-color);
+}
+
+div.check-box.on div.check-box-button {
+    background-color: var(--checkbox-on-button-bg-color);
+    color: var(--checkbox-on-button-color);
+}
+
+input[type=password].styled,
+input[type=text].styled,
+textarea.styled {
+    border: 1px solid var(--input-border-color);
+    background-color: var(--input-bg-color);
+    color: var(--input-color);
+}
+
+input[type=password].styled:FOCUS,
+input[type=text].styled:FOCUS,
+textarea.styled:FOCUS {
+    background-color: var(--input-focus-bg-color);
+}
+
+input[type=password].styled:HOVER,
+input[type=password].styled:FOCUS,
+input[type=text].styled:HOVER,
+input[type=text].styled:FOCUS,
+textarea.styled:HOVER,
+textarea.styled:FOCUS {
+    border-color: var(--input-hover-border-color);
+    color: var(--input-hover-color);
+}
+
+input[readonly] {
+    border: 1px solid var(--input-readonly-border-color) !important;
+}
+
+select.styled {
+    border: 1px solid var(--input-border-color);
+    background-color: var(--input-bg-color);
+    color: var(--input-color);
+}
+
+select.styled:FOCUS {
+    background-color: var(--input-focus-bg-color);
+}
+
+select.styled:HOVER,
+select.styled:FOCUS {
+    border-color: var(--input-hover-border-color);
+    color: var(--input-hover-color);
+}
+
+div.slider-bar-inside {
+    border: 1px solid var(--slider-bar-border-color);
+}
+
+div.slider:HOVER div.slider-bar-inside,
+div.slider:FOCUS div.slider-bar-inside {
+    border-color: var(--slider-hover-bar-border-color);
+}
+
+div.slider:FOCUS div.slider-bar-inside {
+    background-color: var(--slider-focus-bar-bg-color);
+}
+
+div.slider-cursor-label {
+    background: var(--slider-cursor-label-bg-color);
+}
+
+div.progress-bar-container {
+    border: 1px solid var(--progress-bar-border-color);
+}
+
+div.progress-bar-fill {
+    background-color: var(--progress-bar-fill-bg-color);
+}
+
+div.modal-glass {
+    background-color: var(--modal-glass-bg-color);
+}
+
+div.modal-container {
+    background-color: var(--modal-container-bg-color);
+}
+
+span.modal-title {
+    color: var(--modal-title-color);
+}
+
+div.dialog-item-separator {
+    border-top: 1px solid var(--dialog-separator-border-color);
+}
+
+div.popup-message-container {
+    background-color: var(--popup-container-bg-color);
+}
+
+span.popup-message.info {
+    color: var(--popup-info-color);
+}
+
+span.popup-message.error {
+    color: var(--popup-error-color);
+}

--- a/motioneye/static/css/ui.css
+++ b/motioneye/static/css/ui.css
@@ -1,10 +1,8 @@
-
-    /* general */
+/* general */
 
 ::selection,
 ::-moz-selection,
 ::-webkit-selection {
-    background: #3498db;
 }
 
 option::selection,
@@ -18,14 +16,9 @@ input[type=checkbox].styled {
 }
 
 a {
-    color: #3498db;
     text-decoration: inherit;
     transition: color 0.1s ease;
     cursor: pointer;
-}
-
-a:ACTIVE {
-    color: #317CAD;
 }
 
 
@@ -40,20 +33,14 @@ div.button {
 }
 
 div.button.dialog {
-    background-color: #414141;
     min-width: 60px;
     height: 1.2em;
     line-height: 1.2em;
     text-align: center;
     padding: 0.2em 0.4em;
-    border: 1px solid #317CAD;
+    border: 1px solid;
     border-radius: 2px;
-    color: white;
     transition: all 0.1s ease;
-}
-
-div.button.dialog.default {
-    background-color: #317CAD;
 }
 
 div.button.mouse-effect {
@@ -69,10 +56,6 @@ div.button.mouse-effect:ACTIVE {
     opacity: 0.7;
 }
 
-div.icon.mouse-effect:ACTIVE {
-    background-color: rgba(0, 0, 0, 0.5);
-}
-
 
     /* check box */
 
@@ -81,9 +64,8 @@ div.check-box {
     position: relative;
     width: 2.5em;
     height: 1em;
-    border: 1px solid #317CAD;
+    border: 1px solid;
     border-radius: 2px;
-    color: #aaaaaa;
     vertical-align: middle;
     cursor: pointer;
     -webkit-user-select: none;
@@ -93,17 +75,10 @@ div.check-box {
     transition: all 0.2s ease;
 }
 
-div.check-box:FOCUS,
-div.check-box:HOVER {
-    border-color: #3498db;
-}
-
 div.check-box-button {
     width: 50%;
     height: 100%;
     left: 0;
-    background-color: #414141;
-    color: #aaaaaa;
     position: absolute;
     text-align: center;
     line-height: 1em;
@@ -118,13 +93,6 @@ span.check-box-text {
 
 div.check-box.on div.check-box-button {
     left: 50%;
-    background-color: #317CAD;
-    color: white;
-}
-
-div.check-box.on:FOCUS div.check-box-button,
-div.check-box.on:HOVER div.check-box-button {
-    background-color: #3498db;
 }
 
 
@@ -134,11 +102,9 @@ input[type=password].styled,
 input[type=text].styled,
 textarea.styled {
     width: 90%;
-    border: 1px solid #317CAD;
+    border: 1px solid;
     border-radius: 2px;
-    background-color: transparent;
     padding: 1px;
-    color: #dddddd;
     font-family: inherit;
     font-size: 0.8em;
     margin: 2px;
@@ -150,22 +116,6 @@ textarea.styled {
 
 textarea.styled {
     white-space: pre;
-}
-
-input[type=password].styled:FOCUS,
-input[type=text].styled:FOCUS,
-textarea.styled:FOCUS {
-    background-color: #414141;
-}
-
-input[type=password].styled:HOVER,
-input[type=password].styled:FOCUS,
-input[type=text].styled:HOVER,
-input[type=text].styled:FOCUS,
-textarea.styled:HOVER,
-textarea.styled:FOCUS {
-    border-color: #3498db;
-    color: white;
 }
 
 input[type=text].number {
@@ -186,7 +136,7 @@ input[type=text].time {
 }
 
 input[readonly] {
-    border: 1px solid #555 !important;
+    border: 1px solid !important;
 }
 
 
@@ -196,11 +146,9 @@ select.styled {
     -webkit-appearance: none;
     appearance: none;
     width: 90%;
-    border: 1px solid #317CAD;
+    border: 1px solid;
     border-radius: 2px;
-    background-color: transparent;
     padding: 1px 1.25em 1px 1px;
-    color: #dddddd;
     font-family: inherit;
     font-size: 0.8em;
     margin: 2px;
@@ -212,14 +160,7 @@ select.styled {
 }
 
 select.styled:FOCUS {
-    background-color: #414141;
     appearance: auto;
-}
-
-select.styled:HOVER,
-select.styled:FOCUS {
-    border-color: #3498db;
-    color: white;
 }
 
 .ff select.styled {
@@ -265,21 +206,12 @@ div.slider-bar {
 }
 
 div.slider-bar-inside {
-    border: 1px solid #317CAD;
+    border: 1px solid;
     height: 3px;
     position: relative;
     top: 3px;
     left: 7px;
     transition: all 0.1s ease;
-}
-
-div.slider:HOVER div.slider-bar-inside,
-div.slider:FOCUS div.slider-bar-inside {
-    border-color: #3498db;
-}
-
-div.slider:FOCUS div.slider-bar-inside {
-    background-color: #414141;
 }
 
 div.slider-cursor {
@@ -296,7 +228,6 @@ div.slider-cursor-label {
     font-size: 0.6em;
     margin-left: 1.5em;
     margin-top: 0.15em;
-    background: rgba(30, 30, 30, 0.8);
     vertical-align: top;
     padding: 1px 2px;
     border-radius: 3px;
@@ -309,7 +240,7 @@ div.slider-cursor-label {
 div.progress-bar-container {
     position: relative;
     height: 1em;
-    border: 1px solid #555;
+    border: 1px solid;
     vertical-align: middle;
     margin: 0 0.2em;
     text-align: center;
@@ -322,7 +253,6 @@ div.progress-bar-fill {
     top: 0;
     bottom: 0;
     width: 0%;
-    background-color: #555;
     transition: width 0.1s ease;
 }
 
@@ -343,7 +273,6 @@ div.modal-glass {
     right: 0;
     bottom: 0;
     left: 0;
-    background-color: black;
     opacity: 0;
 }
 
@@ -351,7 +280,6 @@ div.modal-container {
     position: fixed;
     display: none;
     z-index: 10001;
-    background-color: #313131;
     border-radius: 3px;
     opacity: 0;
     padding: 5px;
@@ -367,7 +295,6 @@ div.modal-title-bar {
 
 span.modal-title {
     display: inline-block;
-    color: white;
     font-size: 1.2em;
     line-height: 1.2em;
     max-width: 30em;
@@ -429,7 +356,7 @@ span.dialog-item-label {
 
 div.dialog-item-separator {
     height: 1px;
-    border-top: 1px solid #414141;
+    border-top: 1px solid;
     margin: 0.5em 1em;
 }
 
@@ -440,16 +367,11 @@ div.popup-message-container {
     position: fixed;
     display: none;
     z-index: 10002;
-    background-color: #313131;
     border-radius: 3px;
     opacity: 0;
     padding: 5px;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
     top: 60px;
-}
-
-span.popup-message.info {
-    color: white;
 }
 
 span.popup-message.error {

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -821,6 +821,10 @@ function initUI() {
         savePrefs();
     });
 
+    $('#themeSelect').change(function () {
+        savePrefs();
+    });
+
     /* various change handlers */
     $('#storageDeviceSelect').change(function () {
         $('#rootDirectoryEntry').val('/');
@@ -1756,7 +1760,8 @@ function prefsUi2Dict() {
         'fit_frames_vertically': $('#fitFramesVerticallySwitch')[0].checked,
         'layout_rows': parseInt($('#layoutRowsSlider').val()),
         'framerate_factor': $('#framerateDimmerSlider').val() / 100,
-        'resolution_factor': $('#resolutionDimmerSlider').val() / 100
+        'resolution_factor': $('#resolutionDimmerSlider').val() / 100,
+        'theme': $('#themeSelect').val()
     };
 
     return dict;
@@ -1768,6 +1773,7 @@ function dict2PrefsUi(dict) {
     $('#layoutRowsSlider').val(dict['layout_rows']);
     $('#framerateDimmerSlider').val(dict['framerate_factor'] * 100);
     $('#resolutionDimmerSlider').val(dict['resolution_factor'] * 100);
+    $('#themeSelect').val(dict['theme']);
 
     updateConfigUI();
 }
@@ -1785,6 +1791,9 @@ function applyPrefs(dict) {
     else {
         getPageContainer().removeClass('fit-frames-vertically');
     }
+
+    $('body').removeClass('theme-classic theme-dark theme-glass');
+    $('body').addClass('theme-' + dict['theme']);
 }
 
 function savePrefs() {

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -58,6 +58,7 @@
     {% if frame %}
         <link rel="stylesheet" type="text/css" href="{{static_path}}css/frame.css?v={{version}}">
     {% endif %}
+    <link rel="stylesheet" type="text/css" href="{{static_path}}css/themes.css?v={{version}}">
 {% endblock %}
 
 {% block script %}
@@ -148,6 +149,16 @@
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("kadro-variatoro") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="range styled prefs" id="framerateDimmerSlider"></td>
                             <td><span class="help-mark" title="{{ _("reduktas framfrekvencon por ŝpari retan larĝan bandon kaj trafikon (ne funkcias kun simplaj MJPEG-fotiloj)") }}">?</span></td>
+                        </tr>
+                        <tr class="settings-item">
+                            <td class="settings-item-label"><span class="settings-item-label">{{ _("Theme") }}</span></td>
+                            <td class="settings-item-value">
+                                <select class="styled prefs" id="themeSelect">
+                                    <option value="dark">{{ _("Dark") }}</option>
+                                    <option value="glass">{{ _("Glass") }}</option>
+                                </select>
+                            </td>
+                            <td><span class="help-mark" title="{{ _("Changes the UI theme.") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" min="1" max="100" snap="0" ticks="1|20|40|60|80|100" decimals="0">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Rezolucio-variatoro") }}</span></td>


### PR DESCRIPTION
This commit introduces a theme switcher to the motionEye application, allowing users to choose between a dark theme and a glass theme.

The changes include:
- A new `themes.css` file with styles for the dark and glass themes, using CSS variables for easy customization.
- Refactoring of `main.css` and `ui.css` to use the new CSS variables, improving maintainability.
- A dropdown menu in the preferences section of the UI for theme selection.
- Updates to the JavaScript to handle theme changes, apply the selected theme, and save the user's preference.
- Updates to the backend to save the theme preference on a per-user basis.
- The default theme is set to "dark".