### PR TITLE
feat: Improve and internationalize UI tooltip descriptions

### DIFF
--- a/motioneye/locale/en/LC_MESSAGES/motioneye.po
+++ b/motioneye/locale/en/LC_MESSAGES/motioneye.po
@@ -139,7 +139,7 @@ msgstr "Frame Rate Dimmer"
 
 #: motioneye/templates/main.html:150
 msgid "reduktas framfrekvencon por ŝpari retan larĝan bandon kaj trafikon (ne funkcias kun simplaj MJPEG-fotiloj)"
-msgstr "dims the global frame rate to save network bandwidth and traffic (doesn't work on simple MJPEG cameras)"
+msgstr "Reduces the frame rate of all cameras to save network bandwidth and processing power. This does not affect simple MJPEG cameras."
 
 #: motioneye/templates/main.html:153
 msgid "Rezolucio-variatoro"
@@ -147,7 +147,7 @@ msgstr "Resolution Dimmer"
 
 #: motioneye/templates/main.html:155
 msgid "reduktas la efektivan rezolucion de ĉiuj fotiloj por ŝpari retan larĝan bandon kaj trafikon (ne funkcias en simplaj MJPEG-fotiloj)"
-msgstr "dims the actual resolution of all cameras to save network bandwidth and traffic (doesn't work on simple MJPEG cameras)"
+msgstr "Reduces the resolution of all cameras to save network bandwidth and processing power. This does not affect simple MJPEG cameras."
 
 #: motioneye/templates/main.html:161
 msgid "ĝeneralaj parametroj, komunaj al ĉiuj fotiloj"
@@ -171,7 +171,7 @@ msgstr "Admin Username"
 
 #: motioneye/templates/main.html:178
 msgid "la uzantnomo uzata por agordi la sistemon"
-msgstr "the username to be used for configuring the system"
+msgstr "The username for the administrator account, used for system configuration."
 
 #: motioneye/templates/main.html:181 motioneye/templates/main.html:191
 #: motioneye/templates/main.html:521
@@ -180,7 +180,7 @@ msgstr "Password"
 
 #: motioneye/templates/main.html:183
 msgid "pasvorto de administranto"
-msgstr "administrator's password"
+msgstr "The password for the administrator account."
 
 #: motioneye/templates/main.html:186
 msgid "Observanto"
@@ -188,11 +188,11 @@ msgstr "Surveillance Username"
 
 #: motioneye/templates/main.html:188
 msgid "la uzantnomo por uzi por la monitorado"
-msgstr "the username to be used for video surveillance"
+msgstr "The username for a non-administrator account, used for viewing cameras and events."
 
 #: motioneye/templates/main.html:193
 msgid "la pasvorto de la uzanto de monitorado (lasu blankan por monitorado sen pasvorto)"
-msgstr "the password for the surveillance user (leave empty for passwordless surveillance)"
+msgstr "The password for the surveillance user. Leave this field empty to allow access without a password."
 
 #: motioneye/templates/main.html:202
 msgid "motionEye Versio"
@@ -593,7 +593,7 @@ msgstr "Access Key"
 
 #: motioneye/templates/main.html:542
 msgid "The AWS access key used to authenticate with the upload service"
-msgstr "The AWS Access Key Used To Authenticate with the Upload Service"
+msgstr "The AWS access key for your S3-compatible service. This is required for authenticating and uploading files."
 
 #: motioneye/templates/main.html:545
 msgid "Sekreta Alira Ŝlosilo"
@@ -1538,3 +1538,43 @@ msgstr "second"
 #: motioneye/utils/dtconv.py:153
 msgid "minus"
 msgstr "minus"
+#: motioneye/templates/main.html:249
+msgid "Manage the list of known faces for recognition."
+msgstr "Manage the list of familiar faces for person detection and recognition."
+
+#: motioneye/templates/main.html:434
+msgid "The directory where images of known persons will be saved. Leave blank to use the Root Directory."
+msgstr "Specify the directory for storing images of recognized individuals. If left blank, the system's root directory will be used."
+
+#: motioneye/templates/main.html:439
+msgid "The directory where images of unknown persons will be saved. Leave blank to use the Root Directory."
+msgstr "Specify the directory for storing images of unrecognized individuals. If left blank, the system's root directory will be used."
+
+#: motioneye/templates/main.html:444
+msgid "The directory where images of animals will be saved. Leave blank to use the Root Directory."
+msgstr "Specify the directory for storing images of detected animals. If left blank, the system's root directory will be used."
+
+#: motioneye/templates/main.html:363
+msgid "click this button to clear the current mask"
+msgstr "Removes the currently configured privacy or motion detection mask."
+
+#: motioneye/templates/main.html:1060
+msgid "Enable this to detect persons in the captured images. This enables facial recognition and the person-specific folder sorting."
+msgstr "Enable this to detect people in captured images. This is required for facial recognition and sorting images into person-specific folders."
+
+#: motioneye/templates/main.html:1065
+msgid "Enable this to detect animals in the captured images."
+msgstr "Enable this to detect animals in captured images."
+
+#: motioneye/templates/main.html:1169
+msgid "Enable this to send a notification when an animal is detected (uses the same email/Telegram settings)."
+msgstr "Enable this to send a notification when an animal is detected. This uses the same email and Telegram settings as motion notifications."
+
+#: motioneye/templates/main.html:1222
+msgid "enable this if you want a URL to be requested whenever a motion event ends"
+msgstr "Enable this to trigger a webhook (call a URL) when a motion event has finished."
+
+#: motioneye/templates/main.html:1227
+#, python-format
+msgid "a single URL to be requested when motion event ends; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number"
+msgstr "The URL to call when a motion event ends. You can use special tokens like %Y (year), %m (month), %d (day), %H (hour), %M (minute), %S (second), %q (frame number), and %v (event number) to pass event details."

--- a/motioneye/templates/main.html
+++ b/motioneye/templates/main.html
@@ -246,7 +246,7 @@
                         <tr class="settings-item">
                             <td class="settings-item-label"><span class="settings-item-label">Familiar Faces</span></td>
                             <td class="settings-item-value"><div id="manageFacesButton" class="button normal-button">Manage Faces</div></td>
-                            <td><span class="help-mark" title="Manage the list of known faces for recognition.">?</span></td>
+                            <td><span class="help-mark" title="{{ _("Manage the list of known faces for recognition.") }}">?</span></td>
                         </tr>
                     </table>
 
@@ -360,7 +360,7 @@
                         <tr class="settings-item" depends="privacyMask">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>
                             <td class="settings-item-value"><div class="button normal-button clear-mask-button" id="privacyMaskClearButton">Clear Mask</div></td>
-                            <td><span class="help-mark" title="click this button to clear the current mask">?</span></td>
+                            <td><span class="help-mark" title="{{ _("click this button to clear the current mask") }}">?</span></td>
                         </tr>
                         <tr class="settings-item">
                             <td colspan="100"><div class="settings-item-separator"></div></td>
@@ -431,17 +431,17 @@
                         <tr class="settings-item" strip="true" depends="personDetection">
                             <td class="settings-item-label"><span class="settings-item-label">Known Persons Path</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="knownPersonsPathEntry" placeholder="e.g. /var/lib/motioneye/known_persons"></td>
-                            <td><span class="help-mark" title="The directory where images of known persons will be saved. Leave blank to use the Root Directory.">?</span></td>
+                            <td><span class="help-mark" title="{{ _("The directory where images of known persons will be saved. Leave blank to use the Root Directory.") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" strip="true" depends="personDetection">
                             <td class="settings-item-label"><span class="settings-item-label">Unknown Persons Path</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="unknownPersonsPathEntry" placeholder="e.g. /var/lib/motioneye/unknown_persons"></td>
-                            <td><span class="help-mark" title="The directory where images of unknown persons will be saved. Leave blank to use the Root Directory.">?</span></td>
+                            <td><span class="help-mark" title="{{ _("The directory where images of unknown persons will be saved. Leave blank to use the Root Directory.") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" strip="true" depends="animalDetection">
                             <td class="settings-item-label"><span class="settings-item-label">Animals Path</span></td>
                             <td class="settings-item-value"><input type="text" class="styled storage camera-config" id="animalPathEntry" placeholder="e.g. /var/lib/motioneye/animals"></td>
-                            <td><span class="help-mark" title="The directory where images of animals will be saved. Leave blank to use the Root Directory.">?</span></td>
+                            <td><span class="help-mark" title="{{ _("The directory where images of animals will be saved. Leave blank to use the Root Directory.") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="storageDevice=network-share">
                             <td class="settings-item-label"><span class="settings-item-label"></span></td>
@@ -1057,12 +1057,12 @@
                         <tr class="settings-item">
                             <td class="settings-item-label"><span class="settings-item-label">Enable Person Detection</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled motion-detection camera-config" id="personDetectionSwitch"></td>
-                            <td><span class="help-mark" title="Enable this to detect persons in the captured images. This enables facial recognition and the person-specific folder sorting.">?</span></td>
+                            <td><span class="help-mark" title="{{ _("Enable this to detect persons in the captured images. This enables facial recognition and the person-specific folder sorting.") }}">?</span></td>
                         </tr>
                         <tr class="settings-item">
                             <td class="settings-item-label"><span class="settings-item-label">Enable Animal Detection</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled motion-detection camera-config" id="animalDetectionSwitch"></td>
-                            <td><span class="help-mark" title="Enable this to detect animals in the captured images.">?</span></td>
+                            <td><span class="help-mark" title="{{ _("Enable this to detect animals in the captured images.") }}">?</span></td>
                         </tr>
                         {% for config in camera_sections.get('motion-detection', {}).get('configs', []) %}
                             {{config_item(config)}}
@@ -1166,7 +1166,7 @@
                         <tr class="settings-item" depends="motionDetectionEnabled animalDetection">
                             <td class="settings-item-label"><span class="settings-item-label">Notify on Animal Detection</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled notifications camera-config" id="notifyOnAnimalDetectionSwitch"></td>
-                            <td><span class="help-mark" title="Enable this to send a notification when an animal is detected (uses the same email/Telegram settings).">?</span></td>
+                            <td><span class="help-mark" title="{{ _("Enable this to send a notification when an animal is detected (uses the same email/Telegram settings).") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="motionDetectionEnabled">
                             <td colspan="100"><div class="settings-item-separator"></div></td>
@@ -1219,12 +1219,12 @@
                         <tr class="settings-item" depends="motionDetectionEnabled">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Alvoki URL") }}</span></td>
                             <td class="settings-item-value"><input type="checkbox" class="styled notifications camera-config" id="webHookEndNotificationsEnabledSwitch"></td>
-                            <td><span class="help-mark" title="enable this if you want a URL to be requested whenever a motion event ends">?</span></td>
+                            <td><span class="help-mark" title="{{ _("enable this if you want a URL to be requested whenever a motion event ends") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" required="true" depends="webHookEndNotificationsEnabled motionDetectionEnabled" strip="true">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Reteja URL") }}</span></td>
                             <td class="settings-item-value"><input type="text" class="styled notifications camera-config" id="webHookEndNotificationsUrlEntry" placeholder="e.g. http://example.com/notify/"></td>
-                            <td><span class="help-mark" title="a single URL to be requested when motion event ends; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number">?</span></td>
+                            <td><span class="help-mark" title="{{ _("a single URL to be requested when motion event ends; the following special tokens are accepted: %Y = year, %m = month, %d = day, %H = hour, %M = minute, %S = second, %q = frame number, %v = event number") }}">?</span></td>
                         </tr>
                         <tr class="settings-item" depends="webHookEndNotificationsEnabled motionDetectionEnabled">
                             <td class="settings-item-label"><span class="settings-item-label">{{ _("Metodo HTTP") }}</span></td>


### PR DESCRIPTION
Wrapped hardcoded tooltip text in the main HTML template with the gettext function `_()` to make them translatable.

Updated the English translation file (`motioneye.po`) with clearer, more descriptive explanations for UI features.

Added new translations for previously hardcoded tooltips related to person detection, animal detection, and other settings.

This change improves the user experience by providing helpful, context-aware information for various configuration options.