### PR TITLE
ci: fix docker-publish secret names (Username and password required)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,9 +4,9 @@ name: Docker Publish
 # Docker Hub.
 #
 # REQUIRED REPOSITORY SECRETS (Settings -> Secrets and variables -> Actions):
-#   DOCKERHUB_USERNAME  - Docker Hub account name (im1k31s)
-#   DOCKERHUB_TOKEN     - Docker Hub access token with write scope
-#                         (https://hub.docker.com/settings/security)
+#   DOCKER_USERNAME  - Docker Hub account name (im1k31s)
+#   DOCKER_PASSWORD  - Docker Hub access token with Read/Write scope
+#                      (https://app.docker.com/settings -> Personal access tokens)
 #
 # Tagging:
 #   push to main        -> :edge
@@ -46,8 +46,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Derive image tags
         id: meta

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -146,9 +146,10 @@ multi-arch image automatically:
 It requires two repository secrets (**Settings → Secrets and
 variables → Actions**):
 
-- `DOCKERHUB_USERNAME` — `im1k31s`
-- `DOCKERHUB_TOKEN` — a Docker Hub access token with **write** scope,
-  created at <https://hub.docker.com/settings/security>
+- `DOCKER_USERNAME` — `im1k31s`
+- `DOCKER_PASSWORD` — a Docker Hub access token with **Read/Write**
+  scope, created at <https://app.docker.com/settings> → Personal
+  access tokens
 
 Forks skip the workflow automatically (the `if:` guard checks the
 repository name) so they don't fail on missing secrets.


### PR DESCRIPTION
## Problem

The `docker-publish.yml` workflow failed on every run with:

```
##[error]Username and password required
```

That error comes from `docker/login-action`'s own pre-flight check —
it fires when the `username`/`password` inputs resolve to **empty
strings**, i.e. the referenced secrets don't exist.

## Cause

Name mismatch. The workflow referenced `DOCKERHUB_USERNAME` /
`DOCKERHUB_TOKEN`, but the repository secrets are named
`DOCKER_USERNAME` / `DOCKER_PASSWORD`. `${{ secrets.DOCKERHUB_USERNAME }}`
therefore resolved to `""`.

## Fix

Point the workflow at the actual secret names. No secret values
change; the credentials themselves are confirmed working
(`docker login -u im1k31s` → `Login Succeeded` locally).

- `.github/workflows/docker-publish.yml` — use `DOCKER_USERNAME` /
  `DOCKER_PASSWORD`
- `docs/DOCKER.md` — update the documented secret names to match

## After merge

The workflow runs on push to `main`, so merging this triggers a
Docker Hub publish of `im1k31s/motioneye-custom:edge` (multi-arch
amd64 + arm64). Can also be triggered manually via Actions → Docker
Publish → Run workflow.