### PR TITLE
Consolidate MQTT-TLS + Manage Faces auth fix from stale branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ snapshots/
 # Project-specific virtual environment (CONTRIBUTING.md / DEVELOPMENT.md
 # instruct contributors to create this directory).
 motioneye_env/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ technical backend in parentheses.
 | [`docs/DOCKER.md`](docs/DOCKER.md) | Docker deployment — build, compose, devices, troubleshooting |
 | [`docs/MOTIONEYE_LITE.md`](docs/MOTIONEYE_LITE.md) | High-performance native macOS build |
 | [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) | Local dev setup, testing, architecture, debugging |
+| [`SECURITY.md`](SECURITY.md) | Reverse-proxy (Nginx/Apache/Caddy) and MQTT-TLS hardening |
 | [`UNINSTALL.md`](UNINSTALL.md) | Complete removal per platform |
 | [`CHANGELOG.md`](CHANGELOG.md) | Version history and roadmap |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR process and code style |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,111 @@
+# motionEye Security Guide
+
+This document provides guidance on how to secure your motionEye installation.
+
+## Securing the Web Interface with a Reverse Proxy
+
+By default, the motionEye web interface is served over unencrypted HTTP. To secure it with HTTPS, you should place it behind a reverse proxy. This is a standard and highly recommended practice.
+
+Below are example configurations for three popular reverse proxy servers.
+
+**Prerequisites:**
+*   You have a domain name or a dynamic DNS service pointing to your server.
+*   You have installed one of the following reverse proxy servers.
+*   In `motioneye.conf`, it is recommended to set `webcontrol_localhost true` so that the web interface is only accessible through the proxy.
+
+---
+
+### 1. Nginx
+
+Nginx is a high-performance, open-source web server and reverse proxy.
+
+**Example Configuration (`/etc/nginx/sites-available/motioneye`):**
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name your-domain.com;
+
+    # Redirect all HTTP traffic to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name your-domain.com;
+
+    # SSL Certificate paths (managed by Certbot)
+    ssl_certificate /etc/letsencrypt/live/your-domain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+**For more details, see the [Nginx Documentation](https://nginx.org/en/docs/).**
+
+---
+
+### 2. Apache
+
+The Apache HTTP Server is another widely-used, free and open-source web server.
+
+**Example Configuration (`/etc/apache2/sites-available/motioneye.conf`):**
+```apache
+<VirtualHost *:80>
+    ServerName your-domain.com
+    Redirect permanent / https://your-domain.com/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName your-domain.com
+
+    # SSL Certificate paths (managed by Certbot)
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/your-domain.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/your-domain.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyPass / http://127.0.0.1:8765/
+    ProxyPassReverse / http://127.0.0.1:8765/
+</VirtualHost>
+```
+
+**For more details, see the [Apache Documentation](https://httpd.apache.org/docs/).**
+
+---
+
+### 3. Caddy
+
+Caddy is a modern, powerful web server with automatic HTTPS. It is known for its simple configuration.
+
+**Example Configuration (`Caddyfile`):**
+```
+your-domain.com {
+    reverse_proxy 127.0.0.1:8765
+}
+```
+Caddy will automatically provision and renew a TLS certificate for `your-domain.com`.
+
+**For more details, see the [Caddy Documentation](https://caddyserver.com/docs/).**
+
+---
+
+## Securing MQTT with TLS
+
+The Home Assistant integration can be configured to use an encrypted TLS connection to your MQTT broker. This is highly recommended if your broker is accessible over a network.
+
+**To enable MQTT TLS:**
+1.  In the motionEye web UI, open the main settings panel.
+2.  Navigate to the "MQTT Integration" section.
+3.  Enable the **"Enable TLS"** checkbox.
+4.  If your MQTT broker uses a self-signed certificate or a custom Certificate Authority (CA), you must provide the path to the CA certificate file in the **"CA Certificate Path"** field. If you are using a standard, publicly trusted certificate, you can leave this field blank.
+5.  Apply the settings. motionEye will restart and attempt to connect to your broker using a secure connection.
+```

--- a/motioneye/config.py
+++ b/motioneye/config.py
@@ -2417,7 +2417,9 @@ def _set_default_motion(data):
         'broker_address': '',
         'broker_port': 1883,
         'username': '',
-        'password': ''
+        'password': '',
+        'enable_tls': False,
+        'ca_certs_path': ''
     })
 
     data.setdefault('setup_mode', False)

--- a/motioneye/homeassistant.py
+++ b/motioneye/homeassistant.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import paho.mqtt.client as mqtt
+import os
 import time
 
 from motioneye import settings
@@ -28,6 +29,8 @@ class HomeAssistantAgent:
         port = self._mqtt_settings.get('broker_port', 1883)
         username = self._mqtt_settings.get('username')
         password = self._mqtt_settings.get('password')
+        enable_tls = self._mqtt_settings.get('enable_tls', False)
+        ca_certs_path = self._mqtt_settings.get('ca_certs_path', None)
 
         if not broker:
             logging.warning('MQTT enabled but no broker address is configured.')
@@ -38,6 +41,16 @@ class HomeAssistantAgent:
         self._client = mqtt.Client(client_id="motionEye_server")
         if username and password:
             self._client.username_pw_set(username, password)
+
+        if enable_tls:
+            logging.info("MQTT TLS is enabled.")
+            try:
+                # If a path is provided, use it. Otherwise, paho-mqtt will use system default CAs.
+                self._client.tls_set(ca_certs=ca_certs_path if ca_certs_path else None)
+            except Exception as e:
+                logging.error(f"Failed to set MQTT TLS options: {e}")
+                self._enabled = False
+                return
 
         try:
             self._client.connect(broker, port, 60)
@@ -55,7 +68,6 @@ class HomeAssistantAgent:
         camera_id = camera_config['@id']
         camera_name = camera_config['camera_name']
 
-        # Define a device for this camera. This allows Home Assistant to group entities.
         device_info = {
             "identifiers": [f"motioneye_camera_{camera_id}"],
             "name": f"motionEye Camera - {camera_name}",
@@ -63,7 +75,6 @@ class HomeAssistantAgent:
             "model": "motionEye"
         }
 
-        # Discovery topic for motion binary_sensor
         motion_sensor_topic = f"homeassistant/binary_sensor/motioneye_{camera_id}_motion/config"
         motion_state_topic = f"motioneye/camera_{camera_id}/motion"
 
@@ -107,8 +118,7 @@ def get_agent():
 
 
 def mqtt_publish_main(parser, args):
-    """The main function for the mqtt_publish meyectl command.
-    This runs as a separate process and should be a short-lived client."""
+    """The main function for the mqtt_publish meyectl command."""
     import argparse
     from motioneye import config
 
@@ -120,13 +130,14 @@ def mqtt_publish_main(parser, args):
     mqtt_settings = main_config.get('@_mqtt', {})
 
     if not mqtt_settings.get('enabled'):
-        # Don't log an error, just exit gracefully if the feature is disabled.
         return
 
     broker = mqtt_settings.get('broker_address')
     port = mqtt_settings.get('broker_port', 1883)
     username = mqtt_settings.get('username')
     password = mqtt_settings.get('password')
+    enable_tls = mqtt_settings.get('enable_tls', False)
+    ca_certs_path = mqtt_settings.get('ca_certs_path', None)
 
     if not broker:
         logging.error('MQTT is enabled, but no broker address is configured.')
@@ -136,13 +147,19 @@ def mqtt_publish_main(parser, args):
     if username and password:
         client.username_pw_set(username, password)
 
+    if enable_tls:
+        try:
+            client.tls_set(ca_certs=ca_certs_path if ca_certs_path else None)
+        except Exception as e:
+            logging.error(f"MQTT Publisher failed to set TLS options: {e}")
+            return
+
     try:
         client.connect(broker, port, 60)
     except Exception as e:
         logging.error(f"MQTT publisher failed to connect: {e}")
         return
 
-    # Determine topic and payload
     camera_id = options.camera_id
     if options.topic == 'motion_on':
         state_topic = f"motioneye/camera_{camera_id}/motion"
@@ -155,10 +172,7 @@ def mqtt_publish_main(parser, args):
         client.disconnect()
         return
 
-    # Publish the message
     logging.info(f"MQTT Publisher: sending '{payload}' to '{state_topic}'")
     client.publish(state_topic, payload, retain=True)
-
-    # Disconnect gracefully
     client.disconnect()
     logging.debug("MQTT Publisher: disconnected.")

--- a/motioneye/homeassistant.py
+++ b/motioneye/homeassistant.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import paho.mqtt.client as mqtt
-import os
 import time
 
 from motioneye import settings

--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -1002,7 +1002,7 @@ function initUI() {
     $('div#restoreButton').on('click', doRestore);
 
     /* manage faces button */
-    $('div#manageFacesButton').on('click', function () {
+    $('.settings-container').on('click', 'div#manageFacesButton', function () {
         var url = basePath + 'faces.html';
         url = addAuthParams('GET', url);
         window.open(url, '_blank');


### PR DESCRIPTION
Consolidates two branches that contained unmerged-but-valuable work
into one reviewable PR. Both were created before the 2026-05 audit
and were never merged.

## Changes

### 1. MQTT-over-TLS support (from `feature/macos-opencv-homeassistant`, commit \`1226509c\`)

Adds TLS encryption to the Home Assistant MQTT integration:

- \`motioneye/homeassistant.py\` — reads new \`enable_tls\` /
  \`ca_certs_path\` keys from the MQTT settings and calls
  \`paho-mqtt.tls_set()\`. Falls back to system default CAs when no
  custom path is provided. Failure to configure TLS now logs and
  disables the agent rather than silently sending plaintext.
- \`motioneye/config.py\` — adds \`enable_tls=False\` and
  \`ca_certs_path=''\` to the default \`@_mqtt\` block.
- \`SECURITY.md\` (new, 111 lines) — reverse-proxy hardening guides
  for Nginx / Apache / Caddy plus how to configure MQTT-TLS.

### 2. Manage Faces button fix (from \`fix-manage-faces-auth\`, commit \`1353ac00\`)

One-line JS change in \`motioneye/static/js/main.js\`: switches the
\`#manageFacesButton\` click handler from direct binding to event
delegation on \`.settings-container\`. Without this, the button
becomes unresponsive whenever the settings panel is re-rendered.

### 3. Cleanup (this PR)

- Drop duplicate \`import os\` in \`homeassistant.py\` (introduced by
  the cherry-picked MQTT commit; flake8 F811)
- Gitignore \`.DS_Store\`
- Add a \`SECURITY.md\` row to the README documentation table

## Test results

- \`make test\` → **61 passed / 8 skipped / 0 failed** (no regressions)
- Docker image rebuilds clean with these changes (verified before
  Docker Desktop was closed; container start verification deferred —
  underlying code is exercised by the unit tests)

## Conflict resolution notes

Only \`README.md\` conflicted during cherry-pick — kept main's slim
consolidated README (the branch's version predated the 2026-05 doc
audit) and added a \`SECURITY.md\` link to the docs table to preserve
the branch's intent.

## What this PR does NOT add

The branches deleted in the post-audit prune also contained:
- \`NEW_FEATURES.md\` references — superseded by \`docs/USAGE.md\`
- Old Docker install instructions — superseded by \`docs/DOCKER.md\`

Both intentionally dropped during the conflict resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MQTT integration now supports TLS encryption capabilities with optional certificate configuration for enhanced security.

* **Documentation**
  * Added comprehensive security guide covering HTTPS reverse proxy setup (Nginx, Apache, and Caddy) and MQTT-TLS hardening.

* **Chores**
  * Minor repository maintenance improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/M1K31/MotionEye-Custom/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->