### PR TITLE
docs: publish-ready README + Docker Hub description sync

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,3 +71,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Sync the GitHub README to the Docker Hub repo description so
+      # users browsing https://hub.docker.com/r/im1k31s/motioneye-custom
+      # see the same install + feature info as on GitHub.
+      # Only runs on push to main (skip on tags to avoid two updates
+      # racing on a release).
+      - name: Update Docker Hub description
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ env.IMAGE }}
+          readme-filepath: ./README.md
+          # Docker Hub short description: 100 char max.
+          short-description: "motionEye fork - hardened security, cross-platform cameras, Home Assistant integration"
+          enable-url-completion: true

--- a/README.md
+++ b/README.md
@@ -19,13 +19,22 @@ docker run -d \
   --name motioneye \
   --restart unless-stopped \
   -p 8765:8765 \
+  -p 8081:8081 \
   -v motioneye-config:/etc/motioneye \
   -v motioneye-media:/var/lib/motioneye \
-  im1k31s/motioneye-custom:latest
+  im1k31s/motioneye-custom:edge
 ```
 
 Then open <http://localhost:8765/> — you'll be prompted to set the admin
 password on first boot.
+
+### Available tags on [Docker Hub](https://hub.docker.com/r/im1k31s/motioneye-custom)
+
+| Tag | Updated when | Use for |
+|---|---|---|
+| `edge` | every push to `main` | tracking newest changes |
+| `vX.Y.Z` (e.g. `v0.43.1b4`) | git release tags | pinning to a specific release |
+| `latest` | git release tags | newest tagged release |
 
 For native install (Linux, macOS, Windows/WSL2) and the full Docker
 Compose recipe, see [`docs/INSTALLATION.md`](docs/INSTALLATION.md).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,9 @@
 # and uncomment `build:`.
 services:
   motioneye:
-    image: im1k31s/motioneye-custom:latest
+    # `:edge` tracks main; switch to `:latest` or a pinned `:vX.Y.Z`
+    # tag for production.
+    image: im1k31s/motioneye-custom:edge
     # build:
     #   context: ..
     #   dockerfile: docker/Dockerfile

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -5,11 +5,14 @@ the Motion daemon, and ffmpeg — no host-side build needed.
 
 Official image: **`im1k31s/motioneye-custom`** ([Docker Hub](https://hub.docker.com/r/im1k31s/motioneye-custom))
 
-| Tag | Notes |
-|---|---|
-| `latest` | most recent release |
-| `<version>` (e.g. `0.43.1b4`) | pinned release |
-| `edge` | latest commit on `main` (development) |
+<a id="available-tags"></a>
+
+| Tag | Published on | Use for |
+|---|---|---|
+| `edge` | every push to `main` | tracking newest changes — currently the **only available tag** until a release is tagged |
+| `vX.Y.Z` (e.g. `v0.43.1b4`) | git release tags | pinning to a specific release |
+| `vX.Y` | git release tags | latest patch within a minor version |
+| `latest` | git release tags | newest tagged release |
 
 Multi-arch: **linux/amd64** + **linux/arm64**.
 
@@ -26,8 +29,12 @@ docker run -d \
   -v motioneye-config:/etc/motioneye \
   -v motioneye-media:/var/lib/motioneye \
   -v /etc/localtime:/etc/localtime:ro \
-  im1k31s/motioneye-custom:latest
+  im1k31s/motioneye-custom:edge
 ```
+
+> **Tag choice:** `:edge` is published on every push to `main`.
+> `:latest` and `:vX.Y.Z` only exist after a git release tag is
+> pushed (see [tag table](#available-tags) below).
 
 - **8765** — main web UI
 - **8081** — first camera stream port (Motion uses


### PR DESCRIPTION
## Why

The README's Quick Start example uses `im1k31s/motioneye-custom:latest`,
but `:latest` only gets published on a git release tag. Right now only
`:edge` exists on Docker Hub, so anyone copying the README command
gets `manifest unknown`. Also the Docker Hub repo page has no
description — visitors see an empty Overview tab.

## Changes

### `README.md` + `docker/docker-compose.yml` + `docs/DOCKER.md`

- Quick start now uses `:edge` (the tag that's actually published)
- Added "Available tags" tables explaining `edge` / `latest` /
  `vX.Y.Z` semantics
- Exposed port `8081` in the quick-start (symmetric with the docs)

### `.github/workflows/docker-publish.yml`

New step using [`peter-evans/dockerhub-description@v4`] that syncs
the GitHub README to the Docker Hub repository description on every
push to `main`. Reuses the existing `DOCKER_USERNAME` /
`DOCKER_PASSWORD` secrets. Skipped on tag pushes to avoid two
description updates racing on a release.

`short-description` (the one-liner shown on the Docker Hub listing
page) is set to:

> motionEye fork - hardened security, cross-platform cameras, Home Assistant integration

(86 chars; Docker Hub limit is 100.)

## After merge

The publish workflow will:
1. Push fresh `:edge` to Docker Hub (with the README's `:edge`
   reference now matching reality).
2. Sync the README into the Docker Hub repo description so the
   first thing users see at <https://hub.docker.com/r/im1k31s/motioneye-custom>
   is the same install + feature info as on GitHub.

[`peter-evans/dockerhub-description@v4`]: https://github.com/peter-evans/dockerhub-description